### PR TITLE
Add more implicit function naming examples to "keep names" section

### DIFF
--- a/src/content/api.yml
+++ b/src/content/api.yml
@@ -3214,6 +3214,9 @@ body:
       let {fn = function() {}} = {};
       [fn = function() {}] = [];
       ({fn = function() {}} = {});
+      fn = {fn: function() {}}.fn;
+      fn = {'fn': function() {}}.fn;
+      fn = {['f' + 'n']: function() {}}.fn;
 
   - p: >
       However, [minification](#minify) renames symbols to reduce code size and


### PR DESCRIPTION
This adds a few more examples of implicit function naming to the "keep names" section.

I suppose given the final case, "the name property on functions defaults to a nearby identifier" doesn't quite describe where the name comes from, as `'f' + 'n'` is not an identifier. But I'm not sure what a better phrasing is.

`minify` doesn't do anything which would change the function name in these cases, so `keepNames` doesn't need to handle it. Though in future if `minify` condensed `{x: 1}.x` to just `1`, as Terser does, `keepNames` would need to deal with this case.