### PR TITLE
Fix broken link to consequences of direct `eval` section

### DIFF
--- a/src/content/api.yml
+++ b/src/content/api.yml
@@ -1264,7 +1264,7 @@ body:
       </pre>
       <p>
       There is more information about the consequences of direct `eval` and the
-      available alternatives [here](http://localhost:8001/content-types/#direct-eval).
+      available alternatives [here](/content-types/#direct-eval).
       </p>
 
     - >


### PR DESCRIPTION
This link was referencing a local server (`http://localhost:8001`), so it wouldn't work on the actual https://esbuild.github.io page:

![image](https://user-images.githubusercontent.com/1863540/110563886-d052c300-8100-11eb-930d-41c1795ea66c.gif)