### PR TITLE
fix go example for entry names

### DIFF
--- a/src/content/api.yml
+++ b/src/content/api.yml
@@ -3163,7 +3163,7 @@ body:
         func main() {
           result := api.Build(api.BuildOptions{
             EntryPoints: []string{"src/main-app/app.js"},
-            AssetNames:  "[dir]/[name]-[hash]",
+            EntryNames:  "[dir]/[name]-[hash]",
             Outbase:     "src",
             Bundle:      true,
             Outdir:      "out",


### PR DESCRIPTION
Fixing the Go example for entry names to use the BuildOptions.EntryNames field instead of BuildOptions.AssetNames.