### PR TITLE
Updated TypeScript Types URL

### DIFF
--- a/src/content/api.yml
+++ b/src/content/api.yml
@@ -15,7 +15,7 @@ body:
   - p: >
       If you are using JavaScript be sure to check out the
       [JS-specific details](#js-specific-details) section below. You may also
-      find the [TypeScript type definitions](https://github.com/evanw/esbuild/blob/master/lib/types.ts)
+      find the [TypeScript type definitions](https://github.com/evanw/esbuild/blob/master/lib/shared/types.ts)
       for esbuild helpful as a reference. If you are using Go be sure to check
       out the automatically generated [Go documentation](https://pkg.go.dev/github.com/evanw/esbuild/pkg/api).
 


### PR DESCRIPTION
The current URL 404'd, so I updated it to one that I've been finding very handy when configuring esbuild. Thanks!