### PR TITLE
Fix incorrect links in /content-types/

### DIFF
--- a/src/content/content-types.yml
+++ b/src/content/content-types.yml
@@ -328,10 +328,11 @@ body:
       code in the ESM format that has a `default` export is converted to the
       CommonJS format, and then that CommonJS code is imported into another
       module in ESM format, there are two different interpretations of what
-      should happen that are both widely-used (the [Babel](babeljs.io/) way
-      and the [Node](nodejs.org/) way). This is very unfortunate because it
-      causes endless compatibility headaches, especially since JavaScript
-      libraries are often authored in ESM and published as CommonJS.
+      should happen that are both widely-used (the [Babel](https://babeljs.io/)
+      way and the [Node](https://nodejs.org/) way). This is very unfortunate
+      because it causes endless compatibility headaches, especially since
+      JavaScript libraries are often authored in ESM and published as
+      CommonJS.
 
   - p: >
       When esbuild [bundles](/api/#bundle) code that does this, it has to


### PR DESCRIPTION
The links to Babel and Node in [the section "The `default` export can be error-prone"](https://esbuild.github.io/content-types/#default-interop) incorrectly link to eg. https://esbuild.github.io/content-types/babeljs.io/ as they do not have the https prefix. This commit fixes that.