### PR TITLE
Support http/https specifiers

### DIFF
--- a/src/analyze/tree.ts
+++ b/src/analyze/tree.ts
@@ -15,7 +15,15 @@ export let orderChildrenBySize = (
 }
 
 export let accumulatePath = (root: TreeNodeInProgress, path: string, bytesInOutput: number): number => {
-  let parts = path.split('/')
+  let parts;
+  if (/^https?:\/\//.test(path)) {
+    const url = new URL(path);
+    parts = [url.origin, ...url.pathname.slice(1).split("/")];
+    if (url.search) parts[parts.length-1] += url.search;
+  } else {
+   parts = path.split('/')
+  }
+
   let n = parts.length
   let parent = root
   let inputPath = ''

--- a/src/analyze/tree.ts
+++ b/src/analyze/tree.ts
@@ -17,9 +17,14 @@ export let orderChildrenBySize = (
 export let accumulatePath = (root: TreeNodeInProgress, path: string, bytesInOutput: number): number => {
   let parts;
   if (/^https?:\/\//.test(path)) {
-    const url = new URL(path);
-    parts = [url.origin, ...url.pathname.slice(1).split("/")];
-    if (url.search) parts[parts.length-1] += url.search;
+    try {
+      const url = new URL(path)
+      parts = [url.origin, ...url.pathname.slice(1).split("/")]
+      if (url.search) parts[parts.length-1] += url.search
+    } catch (err) {
+      console.error(err)
+      parts = path.split('/')
+    }
   } else {
    parts = path.split('/')
   }


### PR DESCRIPTION
This PR adds support for parsing `http` and `https` specifiers. When they are detected, the origin is treated as one folder.

Before:

<img width="1092" alt="Screenshot 2023-10-05 at 17 04 50" src="https://github.com/esbuild/esbuild.github.io/assets/1062408/21a6a566-e06b-477f-ab43-ec29d992f165">

After:
<img width="1133" alt="Screenshot 2023-10-05 at 17 05 00" src="https://github.com/esbuild/esbuild.github.io/assets/1062408/95dce2f6-0039-4b84-9bb7-7ee68df8dc6c">

Fixes https://github.com/evanw/esbuild/issues/3423