### PR TITLE
Replace host with hosts in examples with serve result

### DIFF
--- a/src/content/api.yml
+++ b/src/content/api.yml
@@ -170,7 +170,7 @@ body:
           outdir: 'dist',
         })
 
-        let { host, port } = await ctx.serve()
+        let { hosts, port } = await ctx.serve()
 
       go: |
         ctx, err := api.Context(api.BuildOptions{
@@ -821,7 +821,7 @@ body:
 
         await ctx.watch()
 
-        let { host, port } = await ctx.serve({
+        let { hosts, port } = await ctx.serve({
           servedir: 'www',
         })
 
@@ -1287,7 +1287,7 @@ body:
           bundle: true,
         })
 
-        let { host, port } = await ctx.serve({
+        let { hosts, port } = await ctx.serve({
           servedir: 'www',
         })
 


### PR DESCRIPTION
Replace `host` with `hosts` in examples with serve result after v0.25 https://github.com/evanw/esbuild/releases/tag/v0.25.0