### PR TITLE
Support empty imports to reduce the size of json

### DIFF
--- a/src/analyze/warnings.ts
+++ b/src/analyze/warnings.ts
@@ -17,7 +17,7 @@ let generateWarnings = (metafile: Metafile): HTMLElement[] => {
 
   for (let i in inputs) {
     let input = inputs[i]
-    for (let record of input.imports) {
+    for (let record of input.imports || []) {
       if (record.original && record.original[0] !== '.') {
         let array = resolvedPaths[record.original] || (resolvedPaths[record.original] = [])
         if (!array.includes(record.path)) array.push(record.path)

--- a/src/analyze/whyfile.ts
+++ b/src/analyze/whyfile.ts
@@ -59,7 +59,7 @@ export let computeImporters = (metafile: Metafile): Info => {
     if (entryPoint) {
       entryPoints[entryPoint] = o
       allEntryPointOutputs.push(o)
-      for (let record of output.imports) {
+      for (let record of output.imports || []) {
         if (!record.external && !hasOwnProperty.call(crossChunkImports, record.path)) {
           crossChunkImports[record.path] = true
         }
@@ -98,7 +98,7 @@ export let computeImporters = (metafile: Metafile): Info => {
     for (let path of current) {
       let input = inputs[path]
 
-      for (let record of input.imports) {
+      for (let record of input.imports || []) {
         if (!record.external && !hasOwnProperty.call(importers, record.path)) {
           importers[record.path] = {
             inputPath_: path,


### PR DESCRIPTION
There are a lot of `"imports": []` which makes the json very large, allow imports to be undefined can reduce the size of the json.

```json
    "../mpv-polyfill/src/polyfill.ts": {
      "bytes": 490,
      "imports": []
    },
```