### PR TITLE
Remove Snowpack reference

### DIFF
--- a/src/content/faq.yml
+++ b/src/content/faq.yml
@@ -273,8 +273,7 @@ body:
       **Used by other projects**
       <p>
       The API is already being used as a library within many other
-      developer tools. For example, [Vite](https://vitejs.dev/)
-      and [Snowpack](https://www.snowpack.dev/) are using
+      developer tools. For example, [Vite](https://vitejs.dev/) is using
       esbuild to transform TypeScript into JavaScript and
       [Amazon CDK](https://aws.amazon.com/cdk/) (Cloud Development Kit)
       and [Phoenix](https://www.phoenixframework.org/) are using


### PR DESCRIPTION
Snowpack is no longer actively maintained since 2022.

https://www.snowpack.dev/

Many projects are using esbuild as a build tool directly, which may be interesting to mention.